### PR TITLE
BUGFIX RELEASE: Observa 0.1.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 <h1>Observa</h1>
-<h4>0.1.0</h4>
+<h4>0.1.1</h4>
 A Node.js server and browser-side client for video sharing, calling, and broadcasting.
 
 Observa provides a system for performing video calls and broadcasts over WebRTC, powered by RTCMultiConnection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "WebSocket Server/Client to watch videos in sync",
   "main": "index.js",
   "scripts": {

--- a/prepare-dependencies.sh
+++ b/prepare-dependencies.sh
@@ -2,6 +2,9 @@
 
 # This script handles the installation of the dependencies needed for Observa. One day, we'll use Grunt or Gulp.
 
+# Check for youtube-dl. We need it for the reference plugin.
+command -v youtube-dl >/dev/null 2>&1 || { echo >&2 "Observa's reference plugin requires youtube-dl but it's not installed.  Aborting."; exit 1; }
+
 # First, install Observa's server-side dependencies.
 echo "Installing dependencies from npm..."
 npm install


### PR DESCRIPTION
Changes:

`prepare-dependencies.sh` now checks for the presence of `youtube-dl` before continuing. This program is required for Observa's reference plugin.
